### PR TITLE
removing bundler gem from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'resque', '~> 1.17'
 
 group :development do
   gem 'minitest', '>= 0'
-  gem 'bundler', '~> 1.1.0'
   gem 'jeweler', '~> 1.8.3'
   gem 'mynyml-redgreen', '~> 0.7.1'
   gem 'timecop'


### PR DESCRIPTION
since it doesn't need to be in gemfile - was forcing me to use older version of bundler. will make it easier for others to contribute without having to change their bundler version in the future.
