### PR TITLE
Feature/pending queue stats and timeseries stats view

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -53,6 +53,7 @@ Alternatively you can include just the metric you wish to record.
     extend Resque::Plugins::JobStats::Duration
     extend Resque::Plugins::JobStats::Timeseries::Enqueued
     extend Resque::Plugins::JobStats::Timeseries::Performed
+    extend Resque::Plugins::JobStats::Timeseries::Pending  # Note: you must include the Enqueued module along with this to get the Pending stats 
 
     @queue = :my_job
     def self.perform(*args)

--- a/lib/resque-job-stats/server/views/job_stats.erb
+++ b/lib/resque-job-stats/server/views/job_stats.erb
@@ -1,8 +1,4 @@
-<h1>Resque Job Stats</h1>
-
-<p class="intro">
-  This page displays statistics about jobs that have been executed.
-</p>
+<%= layout_header %>
 
 <table>
   <tr>
@@ -24,3 +20,4 @@
     </tr>
   <% end %>
 </table>
+

--- a/lib/resque-job-stats/server/views/job_stats_timeseries_hour.erb
+++ b/lib/resque-job-stats/server/views/job_stats_timeseries_hour.erb
@@ -24,3 +24,7 @@
     </tr>
   <% end %>
 </table>
+
+<p class="intro">
+  Note: Pending data is an average for the time period. (1.0 is the basis, meaning there is no wait for a worker)
+</p>

--- a/lib/resque-job-stats/server/views/job_stats_timeseries_hour.erb
+++ b/lib/resque-job-stats/server/views/job_stats_timeseries_hour.erb
@@ -1,0 +1,26 @@
+<%= layout_header %>
+
+<table>
+  <% @jobs.each do |job| %>
+   <tr>
+     <th colspan=4>Job: <%= job.name %></th>
+   </tr>
+   <tr>
+    <th>Time (hours)</th>
+    <%= stat_header(:queued_per_hour) %>
+    <%= stat_header(:performed_per_hour) %>
+    <%= stat_header(:pending_per_hour) %>
+  </tr>
+
+   <tr>
+      <% timeseries_iterator(job, "hour").each do |hour| %>
+        <tr>
+          <td><%= hour.first %></td>
+          <%= timeseries_lookup(job, :queued_per_hour, hour.first) %>
+          <%= timeseries_lookup(job, :performed_per_hour, hour.first) %>
+          <%= pending_average(job, :pending_per_hour, :queued_per_hour, hour.first) %>
+        </tr>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/lib/resque-job-stats/server/views/job_stats_timeseries_minute.erb
+++ b/lib/resque-job-stats/server/views/job_stats_timeseries_minute.erb
@@ -1,0 +1,26 @@
+<%= layout_header %>
+
+<table>
+  <% @jobs.each do |job| %>
+   <tr>
+     <th colspan=4>Job: <%= job.name %></th>
+   </tr>
+   <tr>
+    <th>Time (minutes)</th>
+    <%= stat_header(:queued_per_minute) %>
+    <%= stat_header(:performed_per_minute) %>
+    <%= stat_header(:pending_per_minute) %>
+  </tr>
+
+   <tr>
+      <% timeseries_iterator(job, "minute").each do |minute| %>
+        <tr>
+          <td><%= minute.first %></td>
+          <%= timeseries_lookup(job, :queued_per_minute, minute.first) %>
+          <%= timeseries_lookup(job, :performed_per_minute, minute.first) %>
+          <%= pending_average(job, :pending_per_minute, :queued_per_minute, minute.first) %>
+        </tr>
+      <% end %>
+    </tr>
+  <% end %>
+</table>

--- a/lib/resque-job-stats/server/views/job_stats_timeseries_minute.erb
+++ b/lib/resque-job-stats/server/views/job_stats_timeseries_minute.erb
@@ -24,3 +24,7 @@
     </tr>
   <% end %>
 </table>
+
+<p class="intro">
+  Note: Pending data is an average for the time period. (1.0 is the basis, meaning there is no wait for a worker)
+</p>

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -15,6 +15,7 @@ module Resque
       include Resque::Plugins::JobStats::Duration
       include Resque::Plugins::JobStats::Timeseries::Enqueued
       include Resque::Plugins::JobStats::Timeseries::Performed
+      include Resque::Plugins::JobStats::Timeseries::Pending
 
       def self.extended(base)
         self.measured_jobs << base

--- a/lib/resque/plugins/job_stats/statistic.rb
+++ b/lib/resque/plugins/job_stats/statistic.rb
@@ -6,8 +6,9 @@ module Resque
       class Statistic
         include Comparable
 
+        TIME_SERIES_STATS = [:queued_per_minute, :performed_per_minute, :pending_per_minute, :queued_per_hour, :performed_per_hour, :pending_per_hour] 
         # An array of the default statistics that will be displayed in the web tab
-        DEFAULT_STATS = [:jobs_enqueued, :jobs_performed, :jobs_failed, :job_rolling_avg, :longest_job]
+        DEFAULT_STATS = [:jobs_enqueued, :jobs_performed, :jobs_failed, :job_rolling_avg, :longest_job].concat(TIME_SERIES_STATS)
 
         attr_accessor *[:job_class].concat(DEFAULT_STATS)
 

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -98,7 +98,7 @@ module Resque::Plugins::JobStats::Timeseries::Pending
   include Resque::Plugins::JobStats::Timeseries::Common
 
   # Increments the performed count for the timestamp when job is complete
-  def after_enqueue_job_stats_timeseries_perform(*args)
+  def after_enqueue_job_stats_timeseries_pending(*args)
     incr_timeseries(:pending, Resque.info[:pending])
   end
 

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -40,14 +40,14 @@ module Resque
             "stats:jobs:#{self.name}:timeseries"
           end
 
-          def incr_timeseries(type) # :nodoc:
-            increx(jobs_timeseries_key(type, timestamp, :minutes), (60 * 61)) # 1h + 1m for some buffer
-            increx(jobs_timeseries_key(type, timestamp, :hours), (60 * 60 * 25)) # 24h + 60m for some buffer
+          def incr_timeseries(type, value=1) # :nodoc:
+            increx(jobs_timeseries_key(type, timestamp, :minutes), (60 * 61), value) # 1h + 1m for some buffer
+            increx(jobs_timeseries_key(type, timestamp, :hours), (60 * 60 * 25), value) # 24h + 60m for some buffer
           end
 
           # Increments a key and sets its expiry time
-          def increx(key, ttl)
-            Resque.redis.incr(key)
+          def increx(key, ttl, value)
+            Resque.redis.incrby(key, value)
             Resque.redis.expire(key, ttl)
           end
         end
@@ -91,5 +91,24 @@ module Resque::Plugins::JobStats::Timeseries::Performed
   # Hash of timeseries data over the last 24 hours for completed jobs
   def performed_per_hour
     timeseries_data(:performed, 24, :hours)
+  end
+end
+
+module Resque::Plugins::JobStats::Timeseries::Pending
+  include Resque::Plugins::JobStats::Timeseries::Common
+
+  # Increments the performed count for the timestamp when job is complete
+  def after_enqueue_job_stats_timeseries_perform(*args)
+    incr_timeseries(:pending, Resque.info[:pending])
+  end
+
+  # Hash of timeseries data over the last 60 minutes for completed jobs
+  def pending_per_minute 
+    timeseries_data(:pending, 60, :minutes)
+  end
+
+  # Hash of timeseries data over the last 24 hours for completed jobs
+  def pending_per_hour 
+    timeseries_data(:pending, 24, :hours)
   end
 end

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -97,17 +97,17 @@ end
 module Resque::Plugins::JobStats::Timeseries::Pending
   include Resque::Plugins::JobStats::Timeseries::Common
 
-  # Increments the performed count for the timestamp when job is complete
+  # Increments the pending count for the timestamp when job is complete
   def after_enqueue_job_stats_timeseries_pending(*args)
     incr_timeseries(:pending, Resque.info[:pending])
   end
 
-  # Hash of timeseries data over the last 60 minutes for completed jobs
+  # Hash of timeseries data over the last 60 minutes for pending jobs 
   def pending_per_minute 
     timeseries_data(:pending, 60, :minutes)
   end
 
-  # Hash of timeseries data over the last 24 hours for completed jobs
+  # Hash of timeseries data over the last 24 hours for pending jobs
   def pending_per_hour 
     timeseries_data(:pending, 24, :hours)
   end

--- a/test/test_job_stats.rb
+++ b/test/test_job_stats.rb
@@ -134,6 +134,16 @@ class TestResqueJobStats < MiniTest::Unit::TestCase
     Timecop.return
   end
 
+  def test_queue_pending
+    time = SimpleJob.timestamp
+    3.times do
+      Resque.enqueue(SimpleJob)
+    end
+
+    assert_equal 6, SimpleJob.pending_per_minute[time]
+    assert_equal 6, SimpleJob.pending_per_hour[time]
+  end
+
   def test_measured_jobs
     assert_equal [SimpleJob], Resque::Plugins::JobStats.measured_jobs
   end


### PR DESCRIPTION
adding pending stats to the time series (these tell how many jobs are waiting to be worked on).
also, added the views for all the timeseries data: queued, performed and pending.
added tests for each item.

questions lmk.
btw: cool plugin!
