### PR TITLE
 Add stats.txt for easy integration with monitoring systems like zabbix

### DIFF
--- a/lib/resque-job-stats/server.rb
+++ b/lib/resque-job-stats/server.rb
@@ -52,6 +52,17 @@ module Resque
               @jobs = Resque::Plugins::JobStats::Statistic.find_all(self.class.job_stats_to_display).sort
               erb(File.read(File.join(VIEW_PATH, 'job_stats.erb')))
             end
+
+            app.get '/job_stats.txt' do
+              content_type 'text/plain'
+
+              Resque::Plugins::JobStats::Statistic.find_all(self.class.job_stats_to_display).map do |job|
+                self.class.job_stats_to_display.map do |stat|
+                  "#{job.name}.#{stat}=#{job.send(stat)}"
+                end
+              end.flatten.join("\n")
+            end
+
             # We have little choice in using this funky name - Resque
             # already has a "Stats" tab, and it doesn't like
             # tab names with spaces in it (it translates the url as job%20stats)

--- a/lib/resque-job-stats/server/views/job_stats.erb
+++ b/lib/resque-job-stats/server/views/job_stats.erb
@@ -12,6 +12,8 @@
     <%= stat_header(:jobs_failed) %>
     <%= stat_header(:job_rolling_avg) %>
     <%= stat_header(:longest_job) %>
+    <%= stat_header(:failed_job_rolling_avg) %>
+    <%= stat_header(:longest_failed_job) %>
   </tr>
   <% @jobs.each do |job| %>
     <tr>
@@ -21,6 +23,8 @@
       <%= display_stat(job, :jobs_failed,     :number_display) %>
       <%= display_stat(job, :job_rolling_avg, :time_display) %>
       <%= display_stat(job, :longest_job,     :time_display) %>
+      <%= display_stat(job, :failed_job_rolling_avg, :time_display) %>
+      <%= display_stat(job, :longest_failed_job,     :time_display) %>
     </tr>
   <% end %>
 </table>

--- a/lib/resque/plugins/job_stats/duration.rb
+++ b/lib/resque/plugins/job_stats/duration.rb
@@ -5,41 +5,59 @@ module Resque
 
         # Resets all job durations
         def reset_job_durations
-          Resque.redis.del(jobs_duration_key)
+          Resque.redis.del(jobs_duration_key(true))
+          Resque.redis.del(jobs_duration_key(false))
         end
 
         # Returns the number of jobs failed
-        def job_durations
-          Resque.redis.lrange(jobs_duration_key,0,durations_recorded - 1).map(&:to_f)
+        def job_durations(success=true)
+          Resque.redis.lrange(jobs_duration_key(success),0,durations_recorded - 1).map(&:to_f)
+        end
+
+        def failed_job_durations
+          job_durations(false)
         end
 
         # Returns the key used for tracking job durations
-        def jobs_duration_key
-          "stats:jobs:#{self.name}:duration"
+        def jobs_duration_key(success=true)
+          "stats:jobs:#{self.name}:#{success ? '' : 'failure:'}duration"
         end
 
         # Increments the failed count when job is complete
         def around_perform_job_stats_duration(*args)
           start = Time.now
+          success = true
           yield
+        rescue Exception
+          success = false
+          raise
+        ensure
           duration = Time.now - start
 
-          Resque.redis.lpush(jobs_duration_key, duration)
-          Resque.redis.ltrim(jobs_duration_key, 0, durations_recorded)
+          Resque.redis.lpush(jobs_duration_key(success), duration)
+          Resque.redis.ltrim(jobs_duration_key(success), 0, durations_recorded)
         end
 
         def durations_recorded
           @durations_recorded || 100
         end
 
-        def job_rolling_avg
-          job_times = job_durations
+        def job_rolling_avg(success=true)
+          job_times = job_durations(success)
           return 0.0 if job_times.size == 0.0
           job_times.inject(0.0) {|s,j| s + j} / job_times.size
         end
 
-        def longest_job
-          job_durations.max.to_f
+        def longest_job(success=true)
+          job_durations(success).max.to_f
+        end
+
+        def failed_job_rolling_avg
+          job_rolling_avg(false)
+        end
+
+        def longest_failed_job
+          longest_job(false)
         end
 
       end

--- a/lib/resque/plugins/job_stats/statistic.rb
+++ b/lib/resque/plugins/job_stats/statistic.rb
@@ -7,7 +7,7 @@ module Resque
         include Comparable
 
         # An array of the default statistics that will be displayed in the web tab
-        DEFAULT_STATS = [:jobs_enqueued, :jobs_performed, :jobs_failed, :job_rolling_avg, :longest_job]
+        DEFAULT_STATS = [:jobs_enqueued, :jobs_performed, :jobs_failed, :job_rolling_avg, :longest_job, :failed_job_rolling_avg, :longest_failed_job]
 
         attr_accessor *[:job_class].concat(DEFAULT_STATS)
 


### PR DESCRIPTION
Format is like Resque's stats.txt:

```
AnyJobber.job_rolling_avg=0.3333232
AnyJobber.jobs_enqueued=111
AnyJobber.jobs_failed=0"
AnyJobber.jobs_performed=12345
AnyJobber.longest_job=0.455555
```
