### PR TITLE
Memory usage stats plus weight reduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ doc
 
 # bundler
 .bundle
+vendor
 
 # jeweler generated
 pkg

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'http://rubygems.org'
 
-gem 'resque', '~> 1.17'
+gem 'resque', '1.19'
 
 group :development do
-  gem 'minitest', '>= 0'
+  gem 'minitest', '~>4.0'
   gem 'jeweler', '~> 1.8.3'
   gem 'mynyml-redgreen', '~> 0.7.1'
   gem 'timecop'

--- a/lib/resque-job-stats/server.rb
+++ b/lib/resque-job-stats/server.rb
@@ -32,6 +32,10 @@ module Resque
             num.zero? ? "" : num
           end
 
+          def memory_display(mem)
+            mem.zero? ? "" : ("%.2f" % mem) + "MB"
+          end
+
           def stat_header(stat_name)
             if(display_stat?(stat_name))
               "<th>" + stat_name.to_s.gsub(/_/,' ').capitalize + "</th>"

--- a/lib/resque-job-stats/server/views/job_stats.erb
+++ b/lib/resque-job-stats/server/views/job_stats.erb
@@ -12,15 +12,19 @@
     <%= stat_header(:jobs_failed) %>
     <%= stat_header(:job_rolling_avg) %>
     <%= stat_header(:longest_job) %>
+    <%= stat_header(:job_memory_usage_rolling_avg) %>
+    <%= stat_header(:job_memory_usage_max) %>
   </tr>
   <% @jobs.each do |job| %>
     <tr>
-      <td><%= job.name %></td>      
+      <td><%= job.name %></td>
       <%= display_stat(job, :jobs_enqueued,   :number_display) %>
       <%= display_stat(job, :jobs_performed,  :number_display) %>
       <%= display_stat(job, :jobs_failed,     :number_display) %>
       <%= display_stat(job, :job_rolling_avg, :time_display) %>
       <%= display_stat(job, :longest_job,     :time_display) %>
+      <%= display_stat(job, :job_memory_usage_rolling_avg, :memory_display) %>
+      <%= display_stat(job, :job_memory_usage_max,     :memory_display) %>
     </tr>
   <% end %>
 </table>

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -1,30 +1,13 @@
+# loaded by resque-web 'automagically' to initialize plugin UI
+
 require 'resque'
-require 'resque/plugins/job_stats/performed'
-require 'resque/plugins/job_stats/enqueued'
-require 'resque/plugins/job_stats/failed'
-require 'resque/plugins/job_stats/duration'
-require 'resque/plugins/job_stats/memory_usage'
-require 'resque/plugins/job_stats/timeseries'
+require 'resque/plugins/job_stats/all'
 require 'resque/plugins/job_stats/statistic'
 
 module Resque
   module Plugins
     module JobStats
-      include Resque::Plugins::JobStats::Performed
-      include Resque::Plugins::JobStats::Enqueued
-      include Resque::Plugins::JobStats::Failed
-      include Resque::Plugins::JobStats::Duration
-      include Resque::Plugins::JobStats::MemoryUsage
-      include Resque::Plugins::JobStats::Timeseries::Enqueued
-      include Resque::Plugins::JobStats::Timeseries::Performed
-
-      def self.extended(base)
-        self.measured_jobs << base
-      end
-
-      def self.measured_jobs
-        @measured_jobs ||= []
-      end
+      include Resque::Plugins::JobStats::All
     end
   end
 end

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -3,6 +3,7 @@ require 'resque/plugins/job_stats/performed'
 require 'resque/plugins/job_stats/enqueued'
 require 'resque/plugins/job_stats/failed'
 require 'resque/plugins/job_stats/duration'
+require 'resque/plugins/job_stats/memory_usage'
 require 'resque/plugins/job_stats/timeseries'
 require 'resque/plugins/job_stats/statistic'
 
@@ -13,6 +14,7 @@ module Resque
       include Resque::Plugins::JobStats::Enqueued
       include Resque::Plugins::JobStats::Failed
       include Resque::Plugins::JobStats::Duration
+      include Resque::Plugins::JobStats::MemoryUsage
       include Resque::Plugins::JobStats::Timeseries::Enqueued
       include Resque::Plugins::JobStats::Timeseries::Performed
 

--- a/lib/resque/plugins/job_stats/all.rb
+++ b/lib/resque/plugins/job_stats/all.rb
@@ -1,0 +1,22 @@
+require 'resque/plugins/job_stats/performed'
+require 'resque/plugins/job_stats/enqueued'
+require 'resque/plugins/job_stats/failed'
+require 'resque/plugins/job_stats/duration'
+require 'resque/plugins/job_stats/memory_usage'
+require 'resque/plugins/job_stats/timeseries'
+
+module Resque
+  module Plugins
+    module JobStats
+      module All
+        include Resque::Plugins::JobStats::Performed
+        include Resque::Plugins::JobStats::Enqueued
+        include Resque::Plugins::JobStats::Failed
+        include Resque::Plugins::JobStats::Duration
+        include Resque::Plugins::JobStats::MemoryUsage
+        include Resque::Plugins::JobStats::Timeseries::Enqueued
+        include Resque::Plugins::JobStats::Timeseries::Performed
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/job_stats/duration.rb
+++ b/lib/resque/plugins/job_stats/duration.rb
@@ -2,7 +2,6 @@ module Resque
   module Plugins
     module JobStats
       module Duration
-
         # Resets all job durations
         def reset_job_durations
           Resque.redis.del(jobs_duration_key)
@@ -10,7 +9,7 @@ module Resque
 
         # Returns the number of jobs failed
         def job_durations
-          Resque.redis.lrange(jobs_duration_key,0,durations_recorded - 1).map(&:to_f)
+          Resque.redis.lrange(jobs_duration_key, 0, -1).map(&:to_f)
         end
 
         # Returns the key used for tracking job durations
@@ -25,12 +24,14 @@ module Resque
           duration = Time.now - start
 
           Resque.redis.lpush(jobs_duration_key, duration)
-          Resque.redis.ltrim(jobs_duration_key, 0, durations_recorded)
+          Resque.redis.ltrim(jobs_duration_key, 0, durations_recorded - 1)
         end
 
         def durations_recorded
           @durations_recorded || 100
         end
+
+        attr_writer :durations_recorded
 
         def job_rolling_avg
           job_times = job_durations
@@ -41,7 +42,6 @@ module Resque
         def longest_job
           job_durations.max.to_f
         end
-
       end
     end
   end

--- a/lib/resque/plugins/job_stats/memory_usage.rb
+++ b/lib/resque/plugins/job_stats/memory_usage.rb
@@ -1,0 +1,53 @@
+module Resque
+  module Plugins
+    module JobStats
+      module MemoryUsage
+
+        # Resets all job memory_usages
+        def reset_job_memory_usages
+          Resque.redis.del(jobs_memory_usages_key)
+        end
+
+        # Returns the number of jobs failed
+        def job_memory_usages
+          Resque.redis.lrange(jobs_memory_usage_key,0,memory_usages_recorded - 1).map(&:to_f)
+        end
+
+        # Returns the key used for tracking job memory_usages
+        def jobs_memory_usage_key
+          "stats:jobs:#{self.name}:memory_usage"
+        end
+
+        # Increments the failed count when job is complete
+        def around_perform_job_stats_memory_usage(*args)
+          # Lets zero out stats by triggering full GC sweep that will
+          # elimitate any benefit of copy-on-write forking strategy
+          GC.start
+          # start will usually be equal to amount of memory Rails uses
+          # on startup
+          start = NewRelic::Agent::Samplers::MemorySampler.new.sampler.get_sample
+          yield
+          finish = NewRelic::Agent::Samplers::MemorySampler.new.sampler.get_sample
+          memory_usage = finish - start
+
+          Resque.redis.lpush(jobs_memory_usage_key, memory_usage)
+          Resque.redis.ltrim(jobs_memory_usage_key, 0, memory_usages_recorded)
+        end
+
+        def memory_usages_recorded
+          @memory_usages_recorded || 100
+        end
+
+        def job_memory_usage_rolling_avg
+          job_times = job_memory_usages
+          return 0.0 if job_times.size == 0.0
+          job_times.inject(0.0) {|s,j| s + j} / job_times.size
+        end
+
+        def job_memory_usage_max
+          job_memory_usages.max.to_f
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/plugins/job_stats/memory_usage.rb
+++ b/lib/resque/plugins/job_stats/memory_usage.rb
@@ -2,7 +2,6 @@ module Resque
   module Plugins
     module JobStats
       module MemoryUsage
-
         # Resets all job memory_usages
         def reset_job_memory_usages
           Resque.redis.del(jobs_memory_usages_key)
@@ -10,7 +9,7 @@ module Resque
 
         # Returns the number of jobs failed
         def job_memory_usages
-          Resque.redis.lrange(jobs_memory_usage_key,0,memory_usages_recorded - 1).map(&:to_f)
+          Resque.redis.lrange(jobs_memory_usage_key, 0, -1).map(&:to_f)
         end
 
         # Returns the key used for tracking job memory_usages
@@ -29,12 +28,14 @@ module Resque
           memory_usage = finish - start
 
           Resque.redis.lpush(jobs_memory_usage_key, memory_usage)
-          Resque.redis.ltrim(jobs_memory_usage_key, 0, memory_usages_recorded)
+          Resque.redis.ltrim(jobs_memory_usage_key, 0, memory_usages_recorded - 1)
         end
 
         def memory_usages_recorded
           @memory_usages_recorded || 100
         end
+
+        attr_writer :memory_usages_recorded
 
         def job_memory_usage_rolling_avg
           job_times = job_memory_usages

--- a/lib/resque/plugins/job_stats/memory_usage.rb
+++ b/lib/resque/plugins/job_stats/memory_usage.rb
@@ -66,6 +66,10 @@ module Resque
             # Can not afford to fail here because ALL stats are ALWAYS collected
             # fail 'Newrelic gem is required in order to collect memory usage stats '
           end
+        rescue NewRelic::Agent::Sampler::Unsupported
+          # raised often when restarting workers because they are not allowed
+          # to spawn ps/grep processes when they where already asked to stop
+          nil
         end
       end
     end

--- a/lib/resque/plugins/job_stats/statistic.rb
+++ b/lib/resque/plugins/job_stats/statistic.rb
@@ -7,7 +7,10 @@ module Resque
         include Comparable
 
         # An array of the default statistics that will be displayed in the web tab
-        DEFAULT_STATS = [:jobs_enqueued, :jobs_performed, :jobs_failed, :job_rolling_avg, :longest_job]
+        DEFAULT_STATS = [
+          :jobs_enqueued, :jobs_performed, :jobs_failed, :job_rolling_avg,
+          :longest_job, :job_memory_usage_rolling_avg, :job_memory_usage_max
+        ]
 
         attr_accessor *[:job_class].concat(DEFAULT_STATS)
 

--- a/lib/resque/plugins/job_stats/statistic.rb
+++ b/lib/resque/plugins/job_stats/statistic.rb
@@ -1,6 +1,15 @@
 module Resque
   module Plugins
     module JobStats
+      class JobPlaceholder
+        include Resque::Plugins::JobStats::All
+
+        def initialize(name)
+          @name = name || fail
+        end
+
+        attr_reader :name
+      end
       # A class composed of a job class and the various job statistics
       # collected for the given job.
       class Statistic
@@ -12,29 +21,42 @@ module Resque
           :longest_job, :job_memory_usage_rolling_avg, :job_memory_usage_max
         ]
 
-        attr_accessor *[:job_class].concat(DEFAULT_STATS)
+        attr_accessor :entity, *DEFAULT_STATS
 
         class << self
-          # Find and load a Statistic for all resque jobs that are in the Resque::Plugins::JobStats.measured_jobs collection
+          # Find and load a Statistic for all resque jobs that left their stats in redis
           def find_all(metrics)
-            Resque::Plugins::JobStats.measured_jobs.map{|j| new(j, metrics)}
+            measured_jobs.uniq.sort.map { |name|
+              new(measurable_entity(name), metrics)
+            }
+          end
+
+          private
+
+          # Find names of all resque jobs that left their stats in redis
+          def measured_jobs
+            Resque.redis.keys('stats:jobs:*').map { |o| o.split(/(?<!:):(?!:)/)[2] }
+          end
+
+          def measurable_entity(name)
+            JobPlaceholder.new(name)
           end
         end
 
         # A series of metrics describing one job class.
-        def initialize(job_class, metrics)
-          self.job_class = job_class
+        def initialize(entity, metrics)
+          self.entity = entity
           self.load(metrics)
         end
 
         def load(metrics)
           metrics.each do |metric|
-            self.send("#{metric}=", job_class.send(metric))
+            self.send("#{metric}=", entity.send(metric))
           end
         end
 
         def name
-          self.job_class.name
+          self.entity.name
         end
 
         def <=>(other)

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -15,6 +15,10 @@ module Resque
             Time.at(time.to_i - time.sec).utc   # to_i removes usecs
           end
 
+          def disable_timeseries
+            @disable_timeseries = true
+          end
+
           private
 
           TIME_FORMAT = {:minutes => "%d:%H:%M", :hours => "%d:%H"}
@@ -52,7 +56,8 @@ module Resque
           end
 
           def timeseries_recorded?
-            @timeseries_recorded.nil? ? true : !!@timeseries_recorded
+            # compare with 'true' to discourage setting attribute to 'truthy' values
+            @disable_timeseries != true
           end
         end
       end

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -50,6 +50,10 @@ module Resque
             Resque.redis.incr(key)
             Resque.redis.expire(key, ttl)
           end
+
+          def timeseries_recorded?
+            @timeseries_recorded.nil? ? true : !!@timeseries_recorded
+          end
         end
       end
     end
@@ -61,7 +65,7 @@ module Resque::Plugins::JobStats::Timeseries::Enqueued
 
   # Increments the enqueued count for the timestamp when job is queued
   def after_enqueue_job_stats_timeseries(*args)
-    incr_timeseries(:enqueued)
+    incr_timeseries(:enqueued) if timeseries_recorded?
   end
 
   # Hash of timeseries data over the last 60 minutes for queued jobs
@@ -80,7 +84,7 @@ module Resque::Plugins::JobStats::Timeseries::Performed
 
   # Increments the performed count for the timestamp when job is complete
   def after_perform_job_stats_timeseries(*args)
-    incr_timeseries(:performed)
+    incr_timeseries(:performed) if timeseries_recorded?
   end
 
   # Hash of timeseries data over the last 60 minutes for completed jobs

--- a/test/test_job_stats.rb
+++ b/test/test_job_stats.rb
@@ -133,8 +133,4 @@ class TestResqueJobStats < MiniTest::Unit::TestCase
     assert_equal 1, SimpleJob.performed_per_minute[(time + 60)]
     Timecop.return
   end
-
-  def test_measured_jobs
-    assert_equal [SimpleJob], Resque::Plugins::JobStats.measured_jobs
-  end
 end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -24,6 +24,14 @@ class AnyJobber
     def longest_job
       0.455555
     end
+
+    def job_memory_usage_rolling_avg
+      1.23456789
+    end
+
+    def job_memory_usage_max
+      2.3456789
+    end
   end
 end
 

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -60,29 +60,33 @@ class TestServer < MiniTest::Unit::TestCase
   end
 
   def test_job_stats
-    Resque::Plugins::JobStats.stub :measured_jobs, [AnyJobber] do
-      get '/job_stats'
-      assert_equal 200, last_response.status, last_response.body
-      assert last_response.body.include?("<td>AnyJobber</td>"), "job name was not found"
-      assert last_response.body.include?("<td>111</td>"), "jobs_enqueued was not found"
-      assert last_response.body.include?("<td>12345</td>"), "jobs_performed was not found"
-      assert last_response.body.include?("<td></td>"), "jobs_failed was not found"
-      assert last_response.body.include?("<td>0.33s</td>"),  "job_rolling_avg was not found"
-      assert last_response.body.include?("<td>0.46s</td>"), "longest_job was not found"
+    Resque::Plugins::JobStats::Statistic.stub :measured_jobs, ['AnyJobber'] do
+      Resque::Plugins::JobStats::Statistic.stub :measurable_entity, AnyJobber do
+        get '/job_stats'
+        assert_equal 200, last_response.status, last_response.body
+        assert last_response.body.include?("<td>AnyJobber</td>"), "job name was not found"
+        assert last_response.body.include?("<td>111</td>"), "jobs_enqueued was not found"
+        assert last_response.body.include?("<td>12345</td>"), "jobs_performed was not found"
+        assert last_response.body.include?("<td></td>"), "jobs_failed was not found"
+        assert last_response.body.include?("<td>0.33s</td>"),  "job_rolling_avg was not found"
+        assert last_response.body.include?("<td>0.46s</td>"), "longest_job was not found"
+      end
     end
   end
 
   def test_job_stats_filtered
     Resque::Server.job_stats_to_display = [:longest_job]
-    Resque::Plugins::JobStats.stub :measured_jobs, [AnyJobber] do
-      get '/job_stats'
-      assert_equal 200, last_response.status, last_response.body
-      assert last_response.body.include?("<td>AnyJobber</td>"), "job name was not found"
-      assert !last_response.body.include?("<td>111</td>"), "jobs_enqueued was not found"
-      assert !last_response.body.include?("<td>12345</td>"), "jobs_performed was not found"
-      assert !last_response.body.include?("<td></td>"), "jobs_failed was not found"
-      assert !last_response.body.include?("<td>0.33s</td>"),  "job_rolling_avg was not found"
-      assert last_response.body.include?("<td>0.46s</td>"), "longest_job was not found"
+    Resque::Plugins::JobStats::Statistic.stub :measured_jobs, ['AnyJobber'] do
+      Resque::Plugins::JobStats::Statistic.stub :measurable_entity, AnyJobber do
+        get '/job_stats'
+        assert_equal 200, last_response.status, last_response.body
+        assert last_response.body.include?("<td>AnyJobber</td>"), "job name was not found"
+        assert !last_response.body.include?("<td>111</td>"), "jobs_enqueued was not found"
+        assert !last_response.body.include?("<td>12345</td>"), "jobs_performed was not found"
+        assert !last_response.body.include?("<td></td>"), "jobs_failed was not found"
+        assert !last_response.body.include?("<td>0.33s</td>"),  "job_rolling_avg was not found"
+        assert last_response.body.include?("<td>0.46s</td>"), "longest_job was not found"
+      end
     end
   end
 
@@ -97,7 +101,7 @@ class TestServer < MiniTest::Unit::TestCase
   end
 
   def test_job_sorting
-    Resque::Plugins::JobStats.stub :measured_jobs, [YetAnotherJobber, AnyJobber] do
+    Resque::Plugins::JobStats::Statistic.stub :measured_jobs, ['YetAnotherJobber', 'AnyJobber'] do
       get '/job_stats'
       assert_equal 200, last_response.status, last_response.body
       assert(last_response.body =~ /AnyJobber(.|\n)+YetAnotherJobber/, "AnyJobber should be found before YetAnotherJobber")


### PR DESCRIPTION
Added:
- stricter version requirements on some gems in Gemfile - tests do not run when using newest versions of gem dependencies.
- a way to disable timeseries collection (they generate a lot of noise in redis keys and do not have high value in all use cases).
- memory usage stats collection when NewRelic gem is present (it contains a very useful abstraction helper to get accurate process memory usage on variety of platforms).

Removed:
- requirement for monitored job classes to be loadable in resque-web sinatra app; for most use cases job classes contain plenty of references to rails and app classes overall; loading all of this extra weight is wasteful and unnecessary.