### PR TITLE
Add stats for job histories

### DIFF
--- a/lib/resque-job-stats/server.rb
+++ b/lib/resque-job-stats/server.rb
@@ -44,6 +44,10 @@ module Resque
               "<td>#{formatted_stat}</td>"
             end
           end
+
+          def check_or_cross_stat(value)
+            value ? "&#x2713;" : "&#x2717;"
+          end
         end
 
         class << self
@@ -56,6 +60,21 @@ module Resque
             # already has a "Stats" tab, and it doesn't like
             # tab names with spaces in it (it translates the url as job%20stats)
             app.tabs << "Job_Stats"
+
+            app.get '/job_history/:job_class' do
+              @job_class = Resque::Plugins::JobStats.measured_jobs.find { |j| j.to_s == params[:job_class] }
+              pass unless @job_class
+
+              @start = 0
+              @start = params[:start].to_i if params[:start]
+              @limit = 100
+              @limit = params[:limit].to_i if params[:limit]
+
+              @histories = @job_class.job_histories(@start,@limit)
+              @size = @job_class.histories_recorded
+
+              erb(File.read(File.join(VIEW_PATH, 'job_histories.erb')))
+            end
 
             app.helpers(Helpers)
           end

--- a/lib/resque-job-stats/server/views/job_histories.erb
+++ b/lib/resque-job-stats/server/views/job_histories.erb
@@ -1,0 +1,38 @@
+<h1>Resque Job Histories</h1>
+
+<p class="intro">
+  This page displays histories of jobs that have been executed.
+</p>
+
+<h2><%= @job_class %></h2>
+
+<table>
+  <tr>
+    <th>Start time</th>
+    <th>Duration</th>
+    <th>Arguments</th>
+    <th>Success</th>
+    <th>Exception</th>
+  </tr>
+  <% @histories.each do |history| %>
+    <tr>
+      <td><span class="time"><%= history["run_at"] %></span></td>
+      <td><%= history["duration"] %></td>
+      <td><%= history["args"].inspect %></td>
+      <td><%= check_or_cross_stat(history["success"]) %></td>
+      <td><%= history["exception"]["name"] if history["exception"] %></td>
+    </tr>
+  <% end %>
+</table>
+
+<%if @start > 0 || @start + @limit <= @size %>
+<p class='pagination'>
+  <% if @start - @limit >= 0 %>
+    <a href="<%= current_page %>?start=<%= [0, @start - @limit].max %>&limit=<%= @limit %>" class='less'>&laquo; less</a>
+  <% end %>
+  <% if @start + @limit <= @size %>
+    <a href="<%= current_page %>?start=<%= @start + @limit %>&limit=<%= @limit %>" class='more'>more &raquo;</a>
+  <% end %>
+</p>
+<%end%>
+

--- a/lib/resque-job-stats/server/views/job_stats.erb
+++ b/lib/resque-job-stats/server/views/job_stats.erb
@@ -15,7 +15,13 @@
   </tr>
   <% @jobs.each do |job| %>
     <tr>
-      <td><%= job.name %></td>      
+      <td>
+        <%= job.name %>
+        <% if job.job_class <= Resque::Plugins::JobStats::History ||
+              job.job_class.is_a?(Resque::Plugins::JobStats::History) %>
+          <a href='<%= url "/job_history/#{job.name}" %>'>[history]</a>
+        <% end %>
+      </td>
       <%= display_stat(job, :jobs_enqueued,   :number_display) %>
       <%= display_stat(job, :jobs_performed,  :number_display) %>
       <%= display_stat(job, :jobs_failed,     :number_display) %>

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -5,6 +5,7 @@ require 'resque/plugins/job_stats/failed'
 require 'resque/plugins/job_stats/duration'
 require 'resque/plugins/job_stats/timeseries'
 require 'resque/plugins/job_stats/statistic'
+require 'resque/plugins/job_stats/history'
 
 module Resque
   module Plugins
@@ -15,6 +16,7 @@ module Resque
       include Resque::Plugins::JobStats::Duration
       include Resque::Plugins::JobStats::Timeseries::Enqueued
       include Resque::Plugins::JobStats::Timeseries::Performed
+      include Resque::Plugins::JobStats::History
 
       def self.extended(base)
         self.measured_jobs << base

--- a/lib/resque/plugins/job_stats/history.rb
+++ b/lib/resque/plugins/job_stats/history.rb
@@ -1,0 +1,55 @@
+module Resque
+  module Plugins
+    module JobStats
+      module History
+        include Resque::Helpers
+
+        def job_histories(start=0, limit=histories_recordable)
+          Resque.redis.lrange(jobs_history_key, start, start + limit - 1).map { |h| decode(h) }
+        end
+
+        # Returns the key used for tracking job histories
+        def jobs_history_key
+          "stats:jobs:#{self.name}:history"
+        end
+
+        def around_perform_job_stats_history(*args)
+          # we collect our own duration and start time rather
+          # than correlate with the duration stat to make sure
+          # we're associating them with the right job arguments
+          start = Time.now
+          begin
+            yield
+            duration = Time.now - start
+            push_history "success" => true, "args" => args, "run_at" => start, "duration" => duration
+          rescue Exception => e
+            duration = Time.now - start
+            exception = { "name" => e.to_s, "backtrace" => e.backtrace }
+            push_history "success" => false, "exception" => exception, "args" => args, "run_at" => start, "duration" => duration
+            raise e
+          end
+        end
+
+        def histories_recordable
+          @histories_recordable || 100
+        end
+
+        def histories_recorded
+          Resque.redis.llen(jobs_history_key)
+        end
+
+        def reset_job_histories
+          Resque.redis.del(jobs_history_key)
+        end
+
+        private
+
+        def push_history(history)
+          Resque.redis.lpush(jobs_history_key, encode(history))
+          Resque.redis.ltrim(jobs_history_key, 0, histories_recordable)
+        end
+      end
+    end
+  end
+end
+

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -1,7 +1,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
 require 'resque-job-stats/server'
 
-# A pretend job that has all of the statistics we want to display (i.e. extends 
+# A pretend job that has all of the statistics we want to display (i.e. extends
 # Resque::Plugins::JobStats)
 class AnyJobber
   class << self
@@ -30,6 +30,31 @@ end
 class YetAnotherJobber < AnyJobber
 end
 
+# mocked job with history
+class HistoricJob
+  include Resque::Plugins::JobStats::History
+
+  def self.job_histories(start=0,limit=2)
+    [{"run_at" => "Thu Jan 02 03:45:01 -0700 2012",
+      "duration" => 1.2345,
+      "args" => [1, 2, "3"],
+      "success" => true},
+     {"run_at" => "Thu Jan 02 03:45:01 -0700 2011",
+      "duration" => 6.7890,
+      "args" => ["a", "b"],
+      "success" => false,
+      "exception" => {"name" => "bad stuff", "backtrace" => ["a", "b"]}}][start,limit]
+  end
+
+  def self.histories_recorded
+    2
+  end
+
+  def self.jobs_performed
+    1
+  end
+end
+
 class MyServer
   def self.job_stats_to_display
     [:jobs_enqueued]
@@ -43,7 +68,7 @@ class TestServer < MiniTest::Unit::TestCase
   include Rack::Test::Methods
 
   def setup
-    Resque::Server.job_stats_to_display = Resque::Plugins::JobStats::Statistic::DEFAULT_STATS 
+    Resque::Server.job_stats_to_display = Resque::Plugins::JobStats::Statistic::DEFAULT_STATS
     @server = MyServer.new
   end
 
@@ -55,7 +80,7 @@ class TestServer < MiniTest::Unit::TestCase
     Resque::Plugins::JobStats.stub :measured_jobs, [AnyJobber] do
       get '/job_stats'
       assert_equal 200, last_response.status, last_response.body
-      assert last_response.body.include?("<td>AnyJobber</td>"), "job name was not found"
+      assert last_response.body =~ /<td>\s*AnyJobber\s*<\/td>/, "job name was not found"
       assert last_response.body.include?("<td>111</td>"), "jobs_enqueued was not found"
       assert last_response.body.include?("<td>12345</td>"), "jobs_performed was not found"
       assert last_response.body.include?("<td></td>"), "jobs_failed was not found"
@@ -69,7 +94,7 @@ class TestServer < MiniTest::Unit::TestCase
     Resque::Plugins::JobStats.stub :measured_jobs, [AnyJobber] do
       get '/job_stats'
       assert_equal 200, last_response.status, last_response.body
-      assert last_response.body.include?("<td>AnyJobber</td>"), "job name was not found"
+      assert last_response.body =~ /<td>\s*AnyJobber\s*<\/td>/, "job name was not found"
       assert !last_response.body.include?("<td>111</td>"), "jobs_enqueued was not found"
       assert !last_response.body.include?("<td>12345</td>"), "jobs_performed was not found"
       assert !last_response.body.include?("<td></td>"), "jobs_failed was not found"
@@ -98,5 +123,49 @@ class TestServer < MiniTest::Unit::TestCase
 
   def test_tabs
     assert app.tabs.include?("Job_Stats"), "The tab should be in resque's server"
+  end
+
+  def test_job_stats_history_link
+    Resque::Server.job_stats_to_display = [:jobs_performed]
+    Resque::Plugins::JobStats.stub :measured_jobs, [HistoricJob,AnyJobber] do
+      get "/job_stats"
+      assert_equal 200, last_response.status, last_response.body
+      assert last_response.body.include?("<a href='http://example.org/job_history/HistoricJob'>[history]</a>"), "history link not found"
+      assert !last_response.body.include?("<a href='http://example.org/job_history/AnyJobber'>[history]</a>"), "unexpected history link"
+    end
+  end
+
+  def test_history
+    Resque::Plugins::JobStats.stub :measured_jobs, [HistoricJob] do
+      get "/job_history/HistoricJob"
+      assert_equal 200, last_response.status, last_response.body
+      assert last_response.body.include?("<h2>HistoricJob</h2>"), "job name was not found"
+      assert last_response.body.include?("<td><span class=\"time\">Thu Jan 02 03:45:01 -0700 2012</span></td>"), "start time not found"
+      assert last_response.body.include?("<td>[1, 2, \"3\"]</td>"), "args not found"
+      assert last_response.body.include?("<td>&#x2713;</td>"), "success marker not found"
+    end
+  end
+
+  def test_history_pagination
+    Resque::Plugins::JobStats.stub :measured_jobs, [HistoricJob] do
+      get "/job_history/HistoricJob?start=1"
+      assert_equal 200, last_response.status, last_response.body
+      assert !last_response.body.include?("<td>&#x2713;</td>"), "success marker unexpected"
+      assert last_response.body.include?("<td>&#x2717;</td>"), "failure marker not found"
+      assert last_response.body.include?("<p class='pagination'>"), "pagination links not found"
+
+      get "/job_history/HistoricJob?limit=1"
+      assert_equal 200, last_response.status, last_response.body
+      assert last_response.body.include?("<td>&#x2713;</td>"), "success marker not found"
+      assert !last_response.body.include?("<td>&#x2717;</td>"), "failure marker unexpected"
+      assert last_response.body.include?("<p class='pagination'>"), "pagination links not found"
+    end
+  end
+
+  def test_no_history
+    Resque::Plugins::JobStats.stub :measured_jobs, [AnyJobber] do
+      get "/job_history/HistoricJob"
+      assert_equal 404, last_response.status, last_response.body
+    end
   end
 end


### PR DESCRIPTION
This PR replaces/supersedes #9 by @emilong

> We wanted to be able to drill down into the history for certain jobs if their stats looked unusual. This commit adds argument, timing, and result tracking to the last few (default 100) jobs and a web view to resque-web.

Screen shots of success...

![screen shot 2016-10-20 at 12 00 28 pm](https://cloud.githubusercontent.com/assets/816444/19567735/e5d7af52-96bc-11e6-984f-7ca0d176de97.png)

and failures...

![screen shot 2016-10-20 at 12 00 39 pm](https://cloud.githubusercontent.com/assets/816444/19567734/e5ca655e-96bc-11e6-95e9-f33fdc6a4f01.png)
