### PR TITLE
store job class names in redis instead of instance variable

### DIFF
--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -18,12 +18,16 @@ module Resque
       include Resque::Plugins::JobStats::Timeseries::Performed
       include Resque::Plugins::JobStats::History
 
-      def self.extended(base)
-        self.measured_jobs << base
+      def self.add_measured_job(name)
+        Resque.redis.sadd("stats:jobs", name)
+      end
+
+      def self.rem_measured_job(name)
+        Resque.redis.srem("stats:jobs", name)
       end
 
       def self.measured_jobs
-        @measured_jobs ||= []
+        Resque.redis.smembers("stats:jobs").collect { |c| c.constantize rescue nil }.compact
       end
     end
   end

--- a/lib/resque/plugins/job_stats/duration.rb
+++ b/lib/resque/plugins/job_stats/duration.rb
@@ -24,6 +24,7 @@ module Resque
           yield
           duration = Time.now - start
 
+          Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.lpush(jobs_duration_key, duration)
           Resque.redis.ltrim(jobs_duration_key, 0, durations_recorded)
         end

--- a/lib/resque/plugins/job_stats/enqueued.rb
+++ b/lib/resque/plugins/job_stats/enqueued.rb
@@ -8,6 +8,7 @@ module Resque
 
         # Sets the number of jobs queued
         def jobs_enqueued=(int)
+          Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_enqueued_key,int)
         end
 
@@ -23,6 +24,7 @@ module Resque
 
         # Increments the enqueued count when job is queued
         def after_enqueue_job_stats_enqueued(*args)
+          Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_enqueued_key)
         end
 

--- a/lib/resque/plugins/job_stats/failed.rb
+++ b/lib/resque/plugins/job_stats/failed.rb
@@ -8,6 +8,7 @@ module Resque
 
         # Sets the number of jobs failed
         def jobs_failed=(int)
+          Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_failed_key,int)
         end
 
@@ -25,6 +26,7 @@ module Resque
 
         # Increments the failed count when job is complete
         def on_failure_job_stats_failed(e,*args)
+          Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_failed_key)
         end
 

--- a/lib/resque/plugins/job_stats/performed.rb
+++ b/lib/resque/plugins/job_stats/performed.rb
@@ -8,6 +8,7 @@ module Resque
 
         # Sets the number of jobs performed
         def jobs_performed=(int)
+          Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.set(jobs_performed_key,int)
         end
 
@@ -23,6 +24,7 @@ module Resque
 
         # Increments the performed count when job is complete
         def after_perform_job_stats_performed(*args)
+          Resque::Plugins::JobStats.add_measured_job(self.name)
           Resque.redis.incr(jobs_performed_key)
         end
 

--- a/lib/resque/plugins/job_stats/timeseries.rb
+++ b/lib/resque/plugins/job_stats/timeseries.rb
@@ -41,6 +41,7 @@ module Resque
           end
 
           def incr_timeseries(type) # :nodoc:
+            Resque::Plugins::JobStats.add_measured_job(self.name)
             increx(jobs_timeseries_key(type, timestamp, :minutes), (60 * 61)) # 1h + 1m for some buffer
             increx(jobs_timeseries_key(type, timestamp, :hours), (60 * 60 * 25)) # 24h + 60m for some buffer
           end


### PR DESCRIPTION
Redoing the pull request from #11

Reason: Without this change only one or two job stats are shown in the page and they too are gone if we restart the workers. This is because the measured jobs class names are stored in a instance variable. 

In this change the measured jobs class names are stored in redis along with the stats. So even between every worker restarts the data is persisted.