### PR TITLE
Support Resque 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-gem 'resque', '~> 1.17'

--- a/resque-job-stats.gemspec
+++ b/resque-job-stats.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   
   s.summary = "Job-centric stats for Resque"
 
-  s.add_dependency('resque', '~> 1.17')
+  s.add_dependency('resque', '>= 1.17', '< 3')
 
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest", '~> 5.0'


### PR DESCRIPTION
The tests are able to run for resque 2.

These calls are used by this plugin and none of them seems to be breaking:

```
$ git grep -o -h -E 'Resque[^\S\(]+' | sort | uniq

Resque.enqueue
Resque.redis = 'localhost:6379'
Resque.redis = Redis.new
Resque.redis = Redis.new
Resque.redis.del
Resque.redis.expire
Resque.redis.flushdb
Resque.redis.get
Resque.redis.incr
Resque.redis.llen
Resque.redis.lpush
Resque.redis.lrange
Resque.redis.ltrim
Resque.redis.mget
Resque.redis.namespace
Resque.redis.set
```

Also I am getting this deprecation warning (but no failing tests):
```
Passing 'flushdb' command to redis as is; administrative commands cannot be effectively namespaced and should be called on the redis connection directly; passthrough has been deprecated and will be removed in redis-namespace 2.0 (at ~/.rvm/gems/ruby-2.6.2/gems/resque-2.0.0/lib/resque/data_store.rb:65:in `method_missing')
```


See also 
* https://github.com/alanpeabody/resque-job-stats/issues/16
* https://github.com/nevans/resque-pool/issues/173 (similar)
* https://github.com/resque/resque-scheduler/issues/666 (similar)

The plugin here seems up-to-date from what I can see. Am I missing something?