### PR TITLE
Bump supported ruby: Remove 1.9 and 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 rvm:
-  - 1.9.3
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
-matrix:
-  fast_finish: true
-  include:
-    - rvm: 1.9.2
-      gemfile: Gemfiles/Gemfile.1.9.2
+  - 2.2.10
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 services:
   - redis-server
 before_install:

--- a/Gemfiles/Gemfile.1.9.2
+++ b/Gemfiles/Gemfile.1.9.2
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-group :test do
-  gem 'rake', '> 0.8.7', '< 10.0.3'
-end
-
-gemspec :path => "../"

--- a/resque-job-stats.gemspec
+++ b/resque-job-stats.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.homepage = "http://github.com/alanpeabody/resque-job-stats"
   s.licenses = ["MIT"]
-  s.required_ruby_version = ">= 1.9.2"
+  s.required_ruby_version = ">= 2.2"
   
   s.summary = "Job-centric stats for Resque"
 


### PR DESCRIPTION
We continue to support 2.1, 2.2, and 2.3 although they have been unsupported and ended life years ago.

This is because we rather not want this plugin to force projects to update their ruby version if they for some reason have other dependencies that cannot be updated.

Also adding builds for all recent rubies: 2.6, 2.5, 2.4

Merging this should trigger major release, since we no longer test for support 1.9 and 2.0

