### PR TITLE
Add support for ActiveJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ class MyJob
 end
 ```
 
+If you are using ActiveJob::Base, you need to include it instead:
+
+```ruby
+class MyActiveJob < ActiveJob::Base
+  include Resque::Plugins::JobStats
+
+  queue_as :my_job
+  def perform(*args)
+    # ..
+  end
+end
+```
+
 And you will have a set of keys starting with `'stats:jobs:my_job'` inside your Resque redis namespace.
 
 Alternatively you can include just the metric you wish to record.
@@ -140,7 +153,8 @@ If you wish to display only certain metrics, you can filter the metrics accordin
 * Fork the project
 * Start a feature/bugfix branch
 * Commit and push until you are happy with your contribution
-* Make sure to add tests for it. This is important so I don't break it in a future version unintentionally.
+* Make sure to add tests for it. This is important so I don't break it in a future version unintentionally.  
+* You can use `docker-compose -f test.yml up` to bring up a redis container needed for the tests to run.
 * Please try not to mess with the Rakefile, version, or history. If you want to have your own version, or is otherwise necessary, that is fine, but please isolate to its own commit so I can cherry-pick around it.
 
 ## Contributers

--- a/lib/resque/plugins/job_stats.rb
+++ b/lib/resque/plugins/job_stats.rb
@@ -10,6 +10,40 @@ require 'resque/plugins/job_stats/history'
 module Resque
   module Plugins
     module JobStats
+
+      def self.included(base)
+        # this is all needed to support ActiveJobs 
+        # the main difference is `perform` is an instance method, not a class 
+        # method, and it will not magically call all of our after_<event> hooks
+        base.extend Resque::Plugins::JobStats::Performed
+        base.extend Resque::Plugins::JobStats::Enqueued
+        base.extend Resque::Plugins::JobStats::Failed
+        base.extend Resque::Plugins::JobStats::Duration
+        base.extend Resque::Plugins::JobStats::Timeseries::Enqueued
+        base.extend Resque::Plugins::JobStats::Timeseries::Performed
+        base.extend Resque::Plugins::JobStats::History
+        self.measured_jobs << base
+
+        if base.ancestors.map(&:to_s).include?("ActiveJob::Base")
+          # ActiveJob does not magically call all of our after_perform_ABC methods like resque does
+          base.after_perform do |job|
+            job.class.methods.select do |meth|
+              meth.to_s.start_with?("after_perform_")
+            end.each do |meth|
+              job.class.send(meth)
+            end
+          end
+
+          base.after_enqueue do |job|
+            job.class.methods.select do |meth|
+              meth.to_s.start_with?("after_enqueue_")
+            end.each do |meth|
+              job.class.send(meth)
+            end
+          end
+        end
+      end
+
       include Resque::Plugins::JobStats::Performed
       include Resque::Plugins::JobStats::Enqueued
       include Resque::Plugins::JobStats::Failed

--- a/resque-job-stats.gemspec
+++ b/resque-job-stats.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", '~> 5.0'
   s.add_development_dependency "timecop", '~> 0.6'
   s.add_development_dependency 'rack-test', '>= 0'
+  s.add_development_dependency 'activejob', '>= 5.1.7'
+
 end

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,6 @@
+version: '2.2'
+services:
+  redis:
+    image: redis
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
We were trying to use this gem and realized it was working for normal resque jobs but not for ActiveJob jobs.  The main difference seems to be ActiveJob has `#perform` as an instance method, not a class method - and ActiveJob doesn't support all the magical callbacks based on the method being named something like `after_perform_foobar`.  Both of these issues are alleviated by this PR.  My test passes at least, I will update our application locally to pull from my fork to confirm the tracking is doing what we expect and will report back here. 