### PR TITLE
Add more job statistics

### DIFF
--- a/lib/resque-job-stats/server/views/job_histories.erb
+++ b/lib/resque-job-stats/server/views/job_histories.erb
@@ -11,19 +11,35 @@
     <th>Start time</th>
     <th>Duration</th>
     <th>Arguments</th>
-    <th>Success</th>
-    <th>Exception</th>
+    <th>Execution</th>
+
+    <%# new - fork %>
+    <th>Time spend waiting</th>
+    <th>Jobs in the queue at time of execution</th>
   </tr>
   <% @histories.each do |history| %>
     <tr>
-      <td><span class="time"><%= history["run_at"] %></span></td>
+      <td><%= DateTime.parse(history["run_at"]).strftime("%m/%d/%Y %H:%M:%S") %></td>
       <td><%= history["duration"] %></td>
       <td><%= history["args"].inspect %></td>
-      <td><%= check_or_cross_stat(history["success"]) %></td>
-      <td><%= history["exception"]["name"] if history["exception"] %></td>
+      <td class="<%= history["exception"] ? 'exception' : 'success' %>"><%= history["exception"] ? history["exception"]["name"] : 'Success'  %></td>
+      <td><%= history["been_in_the_queue_for"] %></td>
+      <td><%= history["number_of_jobs_in_queue"] %></td>
     </tr>
   <% end %>
 </table>
+
+<style>
+  .exception {
+    background: #fff0f4;
+    color: #c51244;
+  }
+
+  .success {
+    background: #d4edda;
+    color: #155724;
+  }
+</style>
 
 <%if @start > 0 || @start + @limit <= @size %>
 <p class='pagination'>

--- a/lib/resque/plugins/job_stats/enqueued.rb
+++ b/lib/resque/plugins/job_stats/enqueued.rb
@@ -26,6 +26,28 @@ module Resque
           Resque.redis.incr(jobs_enqueued_key)
         end
 
+        def number_of_jobs_in_queue
+          Resque.size(self.queue)
+        end
+
+        def been_in_the_queue_for(enqueued_since)
+          time_diff(Time.now, enqueued_since)
+        end
+
+        private
+        def time_diff(start_time, end_time)
+          seconds_diff = (start_time - end_time).to_i.abs
+
+          hours = seconds_diff / 3600
+          seconds_diff -= hours * 3600
+
+          minutes = seconds_diff / 60
+          seconds_diff -= minutes * 60
+
+          seconds = seconds_diff
+
+          "#{hours.to_s.rjust(2, '0')}:#{minutes.to_s.rjust(2, '0')}:#{seconds.to_s.rjust(2, '0')}"
+        end
       end
     end
   end

--- a/lib/resque/plugins/job_stats/history.rb
+++ b/lib/resque/plugins/job_stats/history.rb
@@ -18,14 +18,19 @@ module Resque
           # than correlate with the duration stat to make sure
           # we're associating them with the right job arguments
           start = Time.now
+
+          # new - fork
+          number_of_jobs_in_queue = self.number_of_jobs_in_queue
+          been_in_the_queue_for = self.been_in_the_queue_for(args.last.to_time)
+
           begin
             yield
             duration = Time.now - start
-            push_history "success" => true, "args" => args, "run_at" => start, "duration" => duration
+            push_history "success" => true, "args" => args, "run_at" => start, "duration" => duration, "number_of_jobs_in_queue" => number_of_jobs_in_queue, "been_in_the_queue_for" => been_in_the_queue_for
           rescue Exception => e
             duration = Time.now - start
             exception = { "name" => e.to_s, "backtrace" => e.backtrace }
-            push_history "success" => false, "exception" => exception, "args" => args, "run_at" => start, "duration" => duration
+            push_history "success" => false, "exception" => exception, "args" => args, "run_at" => start, "duration" => duration, "number_of_jobs_in_queue" => number_of_jobs_in_queue, "been_in_the_queue_for" => been_in_the_queue_for
             raise e
           end
         end


### PR DESCRIPTION
A couple things added:
- Change Duration format 
- Add new column to to catch how long the job was in the queue BEFORE it started
- Add new column to see how many were in the queue when the job was queued

